### PR TITLE
Bytt baseimage til Temurin med kun JRE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,20 @@
-FROM navikt/java:14
+FROM eclipse-temurin:17 as jre-build
 
-COPY build/libs/*.jar app.jar
+# Create a custom Java runtime
+RUN $JAVA_HOME/bin/jlink \
+         --add-modules java.base,java.xml,java.naming \
+         --strip-debug \
+         --no-man-pages \
+         --no-header-files \
+         --compress=2 \
+         --output /javaruntime
+
+# Runtime
+FROM debian:buster-slim
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH "${JAVA_HOME}/bin:${PATH}"
+COPY --from=jre-build /javaruntime $JAVA_HOME
+
+RUN mkdir /opt/app
+COPY build/libs/*.jar /opt/app/app.jar
+CMD ["java", "-jar", "/opt/app/app.jar"]


### PR DESCRIPTION
Går fra ~483MB til 138MB. Hjelper jo litt.